### PR TITLE
Update for React v15.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ export default scrollableArea(() =>
 ### Intermediate
 
 ```js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { scrollToWhen } from 'react-redux-scroll';
 import { PARAGRAPH_SELECTED } from 'action-types';
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ export default scrollableArea(() =>
 ```js
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { scrollToWhen } from 'react-redux-scroll';
 import { PARAGRAPH_SELECTED } from 'action-types';
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ export default scrollableArea(() =>
 ```js
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { scrollToWhen } from 'react-redux-scroll';
 import { PARAGRAPH_SELECTED } from 'action-types';
 

--- a/package.json
+++ b/package.json
@@ -53,12 +53,14 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
+    "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "rimraf": "^2.6.1",
     "webpack": "^2.2.1"
   },
   "peerDependencies": {
+    "prop-types": "^15.0.0-0",
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
     "react-dom": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
     "redux": "^2.0.0 || ^3.0.0"

--- a/src/scroll-to-when-hoc.js
+++ b/src/scroll-to-when-hoc.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { subscribe } from './middleware';
 

--- a/src/scrollable-area-hoc.js
+++ b/src/scrollable-area-hoc.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 export default (Component) => {


### PR DESCRIPTION
Deprecation of React.PropTypes for prop-types, as detailed in https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html.
